### PR TITLE
Change max duration to max float64

### DIFF
--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -46,8 +46,7 @@ const (
 )
 
 var (
-	maxDuration   = time.Duration(math.MaxInt64)
-	maxDurationMs = durationToMillis(maxDuration)
+	maxDurationMs = math.MaxFloat64
 
 	defaultLatencyHistogramBucketsMs = []float64{
 		2, 4, 6, 8, 10, 50, 100, 200, 400, 800, 1000, 1400, 2000, 5000, 10_000, 15_000, maxDurationMs,


### PR DESCRIPTION
**Description:** 
As defaultLatencyHistogramBucketsMs is an array of float64, we need to change maxDurationMs to max of float64
If we keep maxDurationMs as max of Int64, and the duration is more than max of Int64, it might cause panic at https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/processor.go#L439

**Link to tracking Issue:** 
https://canvadev.atlassian.net/browse/ODC-541

**Testing:** 
Tested in dev cluster