### PR TITLE
Remove infinity bucket in defaultLatencyHistogram

### DIFF
--- a/processor/spanmetricsprocessor/factory_test.go
+++ b/processor/spanmetricsprocessor/factory_test.go
@@ -39,18 +39,13 @@ func TestNewProcessor(t *testing.T) {
 			wantLatencyHistogramBuckets: defaultLatencyHistogramBucketsMs,
 		},
 		{
-			name:                        "latency histogram configured with catch-all bucket to check no additional catch-all bucket inserted",
-			latencyHistogramBuckets:     []time.Duration{2 * time.Millisecond, maxDuration},
-			wantLatencyHistogramBuckets: []float64{2, maxDurationMs},
-		},
-		{
 			name:                    "full config with no catch-all bucket and check the catch-all bucket is inserted",
 			latencyHistogramBuckets: []time.Duration{2 * time.Millisecond},
 			dimensions: []Dimension{
 				{"http.method", &defaultMethod},
 				{"http.status_code", nil},
 			},
-			wantLatencyHistogramBuckets: []float64{2, maxDurationMs},
+			wantLatencyHistogramBuckets: []float64{2},
 			wantDimensions: []Dimension{
 				{"http.method", &defaultMethod},
 				{"http.status_code", nil},

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -17,7 +17,6 @@ package spanmetricsprocessor // import "github.com/open-telemetry/opentelemetry-
 import (
 	"context"
 	"fmt"
-	"math"
 	"sort"
 	"strings"
 	"sync"
@@ -46,10 +45,8 @@ const (
 )
 
 var (
-	maxDurationMs = math.MaxFloat64
-
 	defaultLatencyHistogramBucketsMs = []float64{
-		2, 4, 6, 8, 10, 50, 100, 200, 400, 800, 1000, 1400, 2000, 5000, 10_000, 15_000, maxDurationMs,
+		2, 4, 6, 8, 10, 50, 100, 200, 400, 800, 1000, 1400, 2000, 5000, 10_000, 15_000,
 	}
 )
 
@@ -96,11 +93,6 @@ func newProcessor(logger *zap.Logger, config config.Processor, nextConsumer cons
 	bounds := defaultLatencyHistogramBucketsMs
 	if pConfig.LatencyHistogramBuckets != nil {
 		bounds = mapDurationsToMillis(pConfig.LatencyHistogramBuckets)
-
-		// "Catch-all" bucket.
-		if bounds[len(bounds)-1] != maxDurationMs {
-			bounds = append(bounds, maxDurationMs)
-		}
 	}
 
 	if err := validateDimensions(pConfig.Dimensions, pConfig.skipSanitizeLabel); err != nil {
@@ -431,7 +423,7 @@ func (p *processorImp) resetExemplarData() {
 // updateLatencyMetrics increments the histogram counts for the given metric key and bucket index.
 func (p *processorImp) updateLatencyMetrics(key metricKey, latency float64, index int) {
 	if _, ok := p.latencyBucketCounts[key]; !ok {
-		p.latencyBucketCounts[key] = make([]uint64, len(p.latencyBounds))
+		p.latencyBucketCounts[key] = make([]uint64, len(p.latencyBounds) + 1)
 	}
 	p.latencySum[key] += latency
 	p.latencyCount[key]++

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -159,7 +159,7 @@ func TestConfigureLatencyBounds(t *testing.T) {
 	// Verify
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
-	assert.Equal(t, []float64{0.000003, 0.003, 3, 3000, maxDurationMs}, p.latencyBounds)
+	assert.Equal(t, []float64{0.000003, 0.003, 3, 3000}, p.latencyBounds)
 }
 
 func TestProcessorCapabilities(t *testing.T) {


### PR DESCRIPTION
We have changed to use max float64 in the defaultLatencyHistogram; however it caused OOM because the max float64 is too big.

So instead we remove the infinity bucket, and make the size of the latency histogram is the size of default latency histogram + 1, so for the latency > 15_000ms, it won't cause index out of bound. (and we can have the virtual infinity bucket)

