### PR TITLE
Revert "Remove infinity bucket in defaultLatencyHistogram"

### DIFF
--- a/processor/spanmetricsprocessor/factory_test.go
+++ b/processor/spanmetricsprocessor/factory_test.go
@@ -39,13 +39,18 @@ func TestNewProcessor(t *testing.T) {
 			wantLatencyHistogramBuckets: defaultLatencyHistogramBucketsMs,
 		},
 		{
+			name:                        "latency histogram configured with catch-all bucket to check no additional catch-all bucket inserted",
+			latencyHistogramBuckets:     []time.Duration{2 * time.Millisecond, maxDuration},
+			wantLatencyHistogramBuckets: []float64{2, maxDurationMs},
+		},
+		{
 			name:                    "full config with no catch-all bucket and check the catch-all bucket is inserted",
 			latencyHistogramBuckets: []time.Duration{2 * time.Millisecond},
 			dimensions: []Dimension{
 				{"http.method", &defaultMethod},
 				{"http.status_code", nil},
 			},
-			wantLatencyHistogramBuckets: []float64{2},
+			wantLatencyHistogramBuckets: []float64{2, maxDurationMs},
 			wantDimensions: []Dimension{
 				{"http.method", &defaultMethod},
 				{"http.status_code", nil},

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -159,7 +159,7 @@ func TestConfigureLatencyBounds(t *testing.T) {
 	// Verify
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
-	assert.Equal(t, []float64{0.000003, 0.003, 3, 3000}, p.latencyBounds)
+	assert.Equal(t, []float64{0.000003, 0.003, 3, 3000, maxDurationMs}, p.latencyBounds)
 }
 
 func TestProcessorCapabilities(t *testing.T) {


### PR DESCRIPTION
Reverts Canva/opentelemetry-collector-contrib#3

Revert so we can work on other approach, we will drop span instead if the latency exceed max int64