### PR TITLE
Revert "Change max duration to max float64 (v0.47.0)"

### DIFF
--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -46,7 +46,8 @@ const (
 )
 
 var (
-	maxDurationMs = math.MaxFloat64
+	maxDuration   = time.Duration(math.MaxInt64)
+	maxDurationMs = durationToMillis(maxDuration)
 
 	defaultLatencyHistogramBucketsMs = []float64{
 		2, 4, 6, 8, 10, 50, 100, 200, 400, 800, 1000, 1400, 2000, 5000, 10_000, 15_000, maxDurationMs,


### PR DESCRIPTION
Reverts Canva/opentelemetry-collector-contrib#2

Revert the PR so that we can work on other approach, we will drop the span if the latency exceeds max int64