### PR TITLE
Drop span if latency exceeds max of int64

### DIFF
--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -380,6 +380,15 @@ func (p *processorImp) aggregateMetricsForServiceSpans(rspans pdata.ResourceSpan
 
 func (p *processorImp) aggregateMetricsForSpan(serviceName string, span pdata.Span, resourceAttr pdata.AttributeMap) {
 	latencyInMilliseconds := float64(span.EndTimestamp()-span.StartTimestamp()) / float64(time.Millisecond.Nanoseconds())
+	if latencyInMilliseconds > maxDurationMs {
+		p.logger.Info("Latency exceeds max of int64",
+			zap.String("service.name", serviceName),
+			zap.String("startTimeUnixNano", span.StartTimestamp().String()),
+			zap.String("endTimeUnixNano", span.EndTimestamp().String()),
+			zap.String("span.kind", span.Kind().String()),
+			zap.String("operation", span.Name()))
+		return
+	}
 
 	// Binary search to find the latencyInMilliseconds bucket index.
 	index := sort.SearchFloat64s(p.latencyBounds, latencyInMilliseconds)

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -380,11 +380,12 @@ func (p *processorImp) aggregateMetricsForServiceSpans(rspans pdata.ResourceSpan
 
 func (p *processorImp) aggregateMetricsForSpan(serviceName string, span pdata.Span, resourceAttr pdata.AttributeMap) {
 	latencyInMilliseconds := float64(span.EndTimestamp()-span.StartTimestamp()) / float64(time.Millisecond.Nanoseconds())
+
 	if latencyInMilliseconds > maxDurationMs {
-		p.logger.Info("Latency exceeds max of int64",
+		p.logger.Warn("Latency exceeds max of int64",
 			zap.String("service.name", serviceName),
-			zap.String("startTimeUnixNano", span.StartTimestamp().String()),
-			zap.String("endTimeUnixNano", span.EndTimestamp().String()),
+			zap.Uint64("startTimeUnixNano", uint64(span.StartTimestamp().AsTime().UnixNano())),
+			zap.Uint64("endTimeUnixNano", uint64(span.EndTimestamp().AsTime().UnixNano())),
 			zap.String("span.kind", span.Kind().String()),
 			zap.String("operation", span.Name()))
 		return

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -840,3 +840,50 @@ func TestProcessorResetExemplarData(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, p.latencyExemplarsData[key])
 }
+
+// ------------------------------------------------------- start of additional block of tests -------------------------------------------------------
+
+func TestTraceLatencyExceedMaxInt(t *testing.T) {
+	mexp := &mocks.MetricsExporter{}
+	tcon := &mocks.TracesConsumer{}
+
+	mexp.On("ConsumeMetrics", mock.Anything, mock.Anything).Return(nil)
+	tcon.On("ConsumeTraces", mock.Anything, mock.Anything).Return(nil)
+
+	defaultNullValue := "defaultNullValue"
+	p := newProcessorImp(mexp, tcon, &defaultNullValue, cumulative, t)
+
+	traces := buildTraceWithHighLatency()
+
+	// Test
+	ctx := metadata.NewIncomingContext(context.Background(), nil)
+
+	err := p.ConsumeTraces(ctx, traces)
+	// Validate
+	require.NoError(t, err)
+}
+
+func buildTraceWithHighLatency() pdata.Traces {
+	traces := pdata.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().
+		InsertString(conventions.AttributeServiceName, "test-service")
+	ils := rs.InstrumentationLibrarySpans().AppendEmpty()
+	span := ils.Spans().AppendEmpty()
+	span.SetName("/test")
+	span.SetKind(pdata.SpanKindClient)
+	span.Status().SetCode(pdata.StatusCodeOk)
+	span.SetStartTimestamp(0)
+	span.SetEndTimestamp(18446744073709551615)
+	span.Attributes().InsertString(stringAttrName, "stringAttrValue")
+	span.Attributes().InsertInt(intAttrName, 99)
+	span.Attributes().InsertDouble(doubleAttrName, 99.99)
+	span.Attributes().InsertBool(boolAttrName, true)
+	span.Attributes().InsertNull(nullAttrName)
+	span.Attributes().Insert(mapAttrName, pdata.NewAttributeValueMap())
+	span.Attributes().Insert(arrayAttrName, pdata.NewAttributeValueArray())
+	span.SetTraceID(pdata.NewTraceID([16]byte{byte(42)}))
+	return traces
+}
+
+// ------------------------------------------------------- end of additional block of tests -------------------------------------------------------

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -843,7 +843,7 @@ func TestProcessorResetExemplarData(t *testing.T) {
 
 // ------------------------------------------------------- start of additional block of tests -------------------------------------------------------
 
-func TestTraceLatencyExceedMaxInt(t *testing.T) {
+func TestTraceLatencyExceedsMaxInt64(t *testing.T) {
 	mexp := &mocks.MetricsExporter{}
 	tcon := &mocks.TracesConsumer{}
 


### PR DESCRIPTION
If latency of spans exceed max of int64, we will do nothing.

We just logged the info.