### PR TITLE
Reporter Name Decoder Span Processor

### DIFF
--- a/processor/reporternamedecoderprocessor/README.md
+++ b/processor/reporternamedecoderprocessor/README.md
@@ -1,0 +1,28 @@
+# Reporter Name Processor
+
+This is a custom processor produced at Canva that decodes a two-character reporter name encoding sent from the frontend into its actual name. For example, this processor could receive from the frontend a span with `ReporterName = "-a"` and process it into `ReporterName = "home_page_main"`.
+
+For more information, see the associated [Design Doc](https://docs.google.com/document/d/1GM0FB5PGM4tn9R_JCbJdNxXaV1FEq4HEPyPRjJNRWNY/edit).
+
+## Processor Configuration
+
+Please refer to [config.go](./config.go) for the config spec.
+
+Examples:
+
+```yaml
+processors:
+  reportername:
+    s3_bucket_url: "URL to S3 bucket containing the decoding map for reporter names in JSON for each Canva release"
+```
+
+## S3 Bucket
+
+The S3 bucket should follow the schema of `s3:///reporter-names.canva.com/[RELEASE_NAME]/reporter_names.json` where `reporter_names.json` is an object with encoded names as keys and decoded names as values. For example, `reporter_names.json` ought to look like:
+
+```json
+{
+  "r0": "telemetry_test",
+  "-a": "home_page_main"
+}
+```

--- a/processor/reporternamedecoderprocessor/config.go
+++ b/processor/reporternamedecoderprocessor/config.go
@@ -1,0 +1,16 @@
+package reporternamedecoderprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor"
+
+import (
+	"go.opentelemetry.io/collector/config"
+)
+
+type Config struct {
+	config.ProcessorSettings `mapstructure:",squash"`
+
+	// URL to S3 bucket containing reporter name JSON.
+	// The S3 bucket should follow the schema of
+	// `s3:///reporter-names.canva.com/[RELEASE_NAME]/reporter_names.json`
+	// where `reporter_names.json` is an object with encoded names as keys and
+	// decoded names as values.
+	S3BucketUrl string `mapstructure:"s3_bucket_url"`
+}

--- a/processor/reporternamedecoderprocessor/config_test.go
+++ b/processor/reporternamedecoderprocessor/config_test.go
@@ -1,0 +1,39 @@
+package reporternamedecoderprocessor
+
+import (
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/service/servicetest"
+)
+
+func TestLoadConfig(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.NoError(t, err)
+
+	factories.Processors[typeStr] = NewFactory()
+
+	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "config.yaml"), factories)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+}
+
+func TestLoadConfigEmpty(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	require.NoError(t, err)
+
+	factory := NewFactory()
+	factories.Processors[typeStr] = factory
+
+	cfg, err := servicetest.LoadConfigAndValidate(path.Join(".", "testdata", "empty.yaml"), factories)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	p0 := cfg.Processors[config.NewComponentID(typeStr)]
+	assert.Equal(t, p0, createDefaultConfig())
+}

--- a/processor/reporternamedecoderprocessor/factory.go
+++ b/processor/reporternamedecoderprocessor/factory.go
@@ -1,0 +1,55 @@
+package reporternamedecoderprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/reporternameprocessor"
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+)
+
+const (
+	// The value of "type" key in configuration.
+	typeStr = "reporternamedecoder"
+)
+
+// NewFactory creates a factory for the reporternamedecoder processor.
+func NewFactory() component.ProcessorFactory {
+	return component.NewProcessorFactory(
+		typeStr,
+		createDefaultConfig,
+		component.WithTracesProcessor(createTracesProcessor),
+	)
+}
+
+func createDefaultConfig() config.Processor {
+	return &Config{
+		ProcessorSettings: config.NewProcessorSettings(config.NewComponentID(typeStr)),
+	}
+}
+
+// createTracesProcessor creates an instance of reporternamedecoder for processing traces
+func createTracesProcessor(
+	ctx context.Context,
+	params component.ProcessorCreateSettings,
+	cfg config.Processor,
+	next consumer.Traces,
+) (component.TracesProcessor, error) {
+	oCfg := cfg.(*Config)
+
+	reporterName, err := newReporterNameDecoder(ctx, oCfg, params.Logger, next)
+	if err != nil {
+		// TODO: Placeholder for an error metric in the next PR
+		return nil, fmt.Errorf("error creating a reportername processor: %w", err)
+	}
+
+	return processorhelper.NewTracesProcessor(
+		cfg,
+		next,
+		reporterName.processTraces,
+		processorhelper.WithCapabilities(reporterName.Capabilities()),
+		processorhelper.WithStart(reporterName.Start),
+		processorhelper.WithShutdown(reporterName.Shutdown))
+}

--- a/processor/reporternamedecoderprocessor/factory_test.go
+++ b/processor/reporternamedecoderprocessor/factory_test.go
@@ -1,0 +1,27 @@
+package reporternamedecoderprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+)
+
+func TestDefaultConfiguration(t *testing.T) {
+	c := createDefaultConfig().(*Config)
+	assert.Empty(t, c.S3BucketUrl)
+}
+
+func TestCreateTestProcessor(t *testing.T) {
+	cfg := &Config{
+		ProcessorSettings: config.NewProcessorSettings(config.NewComponentID(typeStr)),
+	}
+
+	tp, err := createTracesProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
+	assert.NoError(t, err)
+	assert.NotNil(t, tp)
+	assert.Equal(t, true, tp.Capabilities().MutatesData)
+}

--- a/processor/reporternamedecoderprocessor/processor.go
+++ b/processor/reporternamedecoderprocessor/processor.go
@@ -1,0 +1,96 @@
+package reporternamedecoderprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/reporternamedecoderprocessor"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+var _ component.TracesProcessor = (*reportername)(nil)
+
+type reportername struct {
+	// ReporterName processor configuration
+	config *Config
+	// Logger
+	logger *zap.Logger
+	// Next trace consumer in line
+	next consumer.Traces
+}
+
+// newReporterNameDecoder creates a new instance of the reporternamedecoder processor
+func newReporterNameDecoder(ctx context.Context, config *Config, logger *zap.Logger, next consumer.Traces) (*reportername, error) {
+	return &reportername{
+		config: config,
+		logger: logger,
+		next:   next,
+	}, nil
+}
+
+// processTraces implements ProcessMetricsFunc. It processes the incoming data
+// and returns the data to be sent to the next component
+func (s *reportername) processTraces(ctx context.Context, batch ptrace.Traces) (ptrace.Traces, error) {
+	for i := 0; i < batch.ResourceSpans().Len(); i++ {
+		rs := batch.ResourceSpans().At(i)
+		s.processResourceSpan(ctx, rs)
+	}
+	return batch, nil
+}
+
+// processResourceSpan processes the RS and all of its spans and then returns the last
+// view metric context. The context can be used for tests
+func (s *reportername) processResourceSpan(ctx context.Context, rs ptrace.ResourceSpans) {
+	rsAttrs := rs.Resource().Attributes()
+
+	// Attributes can be part of a resource span
+	s.processAttrs(ctx, &rsAttrs)
+
+	for j := 0; j < rs.ScopeSpans().Len(); j++ {
+		ils := rs.ScopeSpans().At(j)
+		for k := 0; k < ils.Spans().Len(); k++ {
+			span := ils.Spans().At(k)
+			spanAttrs := span.Attributes()
+
+			// Attributes can also be part of span
+			s.processAttrs(ctx, &spanAttrs)
+		}
+	}
+}
+
+// processAttrs processes the attributes of a resource span or a span
+func (s *reportername) processAttrs(_ context.Context, attributes *pcommon.Map) {
+}
+
+// ConsumeTraces implements the SpanProcessor interface
+func (s *reportername) ConsumeTraces(ctx context.Context, batch ptrace.Traces) error {
+	batch, err := s.processTraces(ctx, batch)
+	if err != nil {
+		return err
+	}
+
+	err = s.next.ConsumeTraces(ctx, batch)
+	return err
+}
+
+const (
+	debug = "debug"
+	info  = "info"
+)
+
+// Capabilities specifies what this processor does, such as whether it mutates data
+func (s *reportername) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: true}
+}
+
+// Start the reporternamedecoder processor
+func (s *reportername) Start(_ context.Context, _ component.Host) error {
+	return nil
+}
+
+// Shutdown the reporternamedecoder processor
+func (s *reportername) Shutdown(context.Context) error {
+	return nil
+}

--- a/processor/reporternamedecoderprocessor/testdata/config.yaml
+++ b/processor/reporternamedecoderprocessor/testdata/config.yaml
@@ -1,0 +1,20 @@
+receivers:
+  nop:
+
+processors:
+  reporternamedecoder:
+    s3_bucket_url: "Some url"
+
+exporters:
+  nop:
+
+service:
+  pipelines:
+    traces:
+      receivers:
+        - nop
+      processors:
+        - reporternamedecoder
+      exporters:
+        - nop
+

--- a/processor/reporternamedecoderprocessor/testdata/empty.yaml
+++ b/processor/reporternamedecoderprocessor/testdata/empty.yaml
@@ -1,0 +1,19 @@
+receivers:
+  nop:
+
+processors:
+  reporternamedecoder:
+
+exporters:
+  nop:
+
+service:
+  pipelines:
+    traces:
+      receivers:
+        - nop
+      processors:
+        - reporternamedecoder
+      exporters:
+        - nop
+


### PR DESCRIPTION
# Reporter Name Processor

This is a custom processor produced at Canva that decodes a two-character reporter name encoding sent from the frontend into its actual name. For example, this processor could receive from the frontend a span with `ReporterName = "-a"` and process it into `ReporterName = "home_page_main"`.

For more information, see the associated [Design Doc](https://docs.google.com/document/d/1GM0FB5PGM4tn9R_JCbJdNxXaV1FEq4HEPyPRjJNRWNY/edit).

## Processor Configuration

Please refer to [config.go](./config.go) for the config spec.

Examples:

```yaml
processors:
  reportername:
    s3_bucket_url: "URL to S3 bucket containing the decoding map for reporter names in JSON for each Canva release"
```

## S3 Bucket

The S3 bucket should follow the schema of `s3:///reporter-names.canva.com/[RELEASE_NAME]/reporter_names.json` where `reporter_names.json` is an object with encoded names as keys and decoded names as values. For example, `reporter_names.json` ought to look like:

```json
{
  "r0": "telemetry_test",
  "-a": "home_page_main"
}
```
