### PR TITLE
Fix compression in the awskinesisexporter and thread safe

### DIFF
--- a/.chloggen/fix-compression-kinesis-exporter.yaml
+++ b/.chloggen/fix-compression-kinesis-exporter.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "bug_fix"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: "awskinesisexporter"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixes the compression by closing it so that it marks the end of the compression and makes it thread safe"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [5663]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/awskinesisexporter/exporter.go
+++ b/exporter/awskinesisexporter/exporter.go
@@ -89,7 +89,7 @@ func createExporter(ctx context.Context, c component.Config, log *zap.Logger, op
 		return nil, err
 	}
 
-	compressor, err := compress.NewCompressor(conf.Encoding.Compression)
+	compressor, err := compress.NewCompressor(conf.Encoding.Compression, log)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/awskinesisexporter/internal/compress/compresser.go
+++ b/exporter/awskinesisexporter/internal/compress/compresser.go
@@ -10,11 +10,14 @@ import (
 	"compress/zlib"
 	"fmt"
 	"io"
+	"sync"
+
+	"go.uber.org/zap"
 )
 
 type bufferedResetWriter interface {
 	Write(p []byte) (int, error)
-	Flush() error
+	Close() error
 	Reset(newWriter io.Writer)
 }
 
@@ -25,35 +28,65 @@ type Compressor interface {
 var _ Compressor = (*compressor)(nil)
 
 type compressor struct {
-	compression bufferedResetWriter
+	compressionPool sync.Pool
 }
 
-func NewCompressor(format string) (Compressor, error) {
-	c := &compressor{
-		compression: &noop{},
-	}
+func NewCompressor(format string, log *zap.Logger) (Compressor, error) {
+	var c Compressor
 	switch format {
 	case "flate":
-		w, err := flate.NewWriter(nil, flate.BestSpeed)
-		if err != nil {
-			return nil, err
+		c = &compressor{
+			compressionPool: sync.Pool{
+				New: func() any {
+					w, err := flate.NewWriter(nil, flate.BestSpeed)
+					if err != nil {
+						err_msg := fmt.Sprintf("Unable to instantiate Flat compressor: %v", err)
+						log.Error(err_msg)
+					}
+					return w
+				},
+			},
 		}
-		c.compression = w
 	case "gzip":
-		w, err := gzip.NewWriterLevel(nil, gzip.BestSpeed)
-		if err != nil {
-			return nil, err
-		}
-		c.compression = w
+		//w, err := gzip.NewWriterLevel(nil, gzip.BestSpeed)
+		//if err != nil {
+		//	return nil, err
+		//}
+		//c.compression = w
 
-	case "zlib":
-		w, err := zlib.NewWriterLevel(nil, zlib.BestSpeed)
-		if err != nil {
-			return nil, err
+		c = &compressor{
+			compressionPool: sync.Pool{
+				New: func() any {
+					w, err := gzip.NewWriterLevel(nil, gzip.BestSpeed)
+					if err != nil {
+						err_msg := fmt.Sprintf("Unable to instantiate Flat compressor: %v", err)
+						log.Error(err_msg)
+					}
+					return w
+				},
+			},
 		}
-		c.compression = w
+	case "zlib":
+		c = &compressor{
+			compressionPool: sync.Pool{
+				New: func() any {
+					w, err := zlib.NewWriterLevel(nil, zlib.BestSpeed)
+					if err != nil {
+						err_msg := fmt.Sprintf("Unable to instantiate Flat compressor: %v", err)
+						log.Error(err_msg)
+					}
+					return w
+				},
+			},
+		}
 	case "noop", "none":
-		// Already the default case
+		c = &compressor{
+			compressionPool: sync.Pool{
+				New: func() any {
+					return &noop{}
+				},
+			},
+		}
 	default:
 		return nil, fmt.Errorf("unknown compression format: %s", format)
 	}
@@ -63,14 +96,19 @@ func NewCompressor(format string) (Compressor, error) {
 
 func (c *compressor) Do(in []byte) ([]byte, error) {
 	buf := new(bytes.Buffer)
+	comp := c.compressionPool.Get().(bufferedResetWriter)
+	if comp == nil {
+		return nil, fmt.Errorf("compressor is nil and did not get instantiated correctly")
+	}
+	defer c.compressionPool.Put(comp)
 
-	c.compression.Reset(buf)
+	comp.Reset(buf)
 
-	if _, err := c.compression.Write(in); err != nil {
+	if _, err := comp.Write(in); err != nil {
 		return nil, err
 	}
 
-	if err := c.compression.Flush(); err != nil {
+	if err := comp.Close(); err != nil {
 		return nil, err
 	}
 

--- a/exporter/awskinesisexporter/internal/compress/compresser.go
+++ b/exporter/awskinesisexporter/internal/compress/compresser.go
@@ -42,6 +42,7 @@ func NewCompressor(format string, log *zap.Logger) (Compressor, error) {
 					if err != nil {
 						errMsg := fmt.Sprintf("Unable to instantiate Flate compressor: %v", err)
 						log.Error(errMsg)
+						return nil
 					}
 					return w
 				},
@@ -56,6 +57,7 @@ func NewCompressor(format string, log *zap.Logger) (Compressor, error) {
 					if err != nil {
 						errMsg := fmt.Sprintf("Unable to instantiate Gzip compressor: %v", err)
 						log.Error(errMsg)
+						return nil
 					}
 					return w
 				},
@@ -69,6 +71,7 @@ func NewCompressor(format string, log *zap.Logger) (Compressor, error) {
 					if err != nil {
 						errMsg := fmt.Sprintf("Unable to instantiate Zlib compressor: %v", err)
 						log.Error(errMsg)
+						return nil
 					}
 					return w
 				},

--- a/exporter/awskinesisexporter/internal/compress/compresser.go
+++ b/exporter/awskinesisexporter/internal/compress/compresser.go
@@ -40,27 +40,22 @@ func NewCompressor(format string, log *zap.Logger) (Compressor, error) {
 				New: func() any {
 					w, err := flate.NewWriter(nil, flate.BestSpeed)
 					if err != nil {
-						err_msg := fmt.Sprintf("Unable to instantiate Flat compressor: %v", err)
-						log.Error(err_msg)
+						errMsg := fmt.Sprintf("Unable to instantiate Flate compressor: %v", err)
+						log.Error(errMsg)
 					}
 					return w
 				},
 			},
 		}
 	case "gzip":
-		//w, err := gzip.NewWriterLevel(nil, gzip.BestSpeed)
-		//if err != nil {
-		//	return nil, err
-		//}
-		//c.compression = w
 
 		c = &compressor{
 			compressionPool: sync.Pool{
 				New: func() any {
 					w, err := gzip.NewWriterLevel(nil, gzip.BestSpeed)
 					if err != nil {
-						err_msg := fmt.Sprintf("Unable to instantiate Flat compressor: %v", err)
-						log.Error(err_msg)
+						errMsg := fmt.Sprintf("Unable to instantiate Gzip compressor: %v", err)
+						log.Error(errMsg)
 					}
 					return w
 				},
@@ -72,8 +67,8 @@ func NewCompressor(format string, log *zap.Logger) (Compressor, error) {
 				New: func() any {
 					w, err := zlib.NewWriterLevel(nil, zlib.BestSpeed)
 					if err != nil {
-						err_msg := fmt.Sprintf("Unable to instantiate Flat compressor: %v", err)
-						log.Error(err_msg)
+						errMsg := fmt.Sprintf("Unable to instantiate Zlib compressor: %v", err)
+						log.Error(errMsg)
 					}
 					return w
 				},

--- a/exporter/awskinesisexporter/internal/compress/compresser_test.go
+++ b/exporter/awskinesisexporter/internal/compress/compresser_test.go
@@ -8,6 +8,7 @@ import (
 	"compress/flate"
 	"compress/gzip"
 	"compress/zlib"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -30,7 +31,7 @@ func GzipDecompress(data []byte) ([]byte, error) {
 	}
 
 	out := bytes.Buffer{}
-	if _, err = io.CopyN(&out, zr, 1024); err != nil && err != io.EOF {
+	if _, err = io.CopyN(&out, zr, 1024); err != nil && !errors.Is(err, io.EOF) {
 		zr.Close()
 		return nil, err
 	}
@@ -51,7 +52,7 @@ func ZlibDecompress(data []byte) ([]byte, error) {
 	}
 
 	out := bytes.Buffer{}
-	if _, err = io.CopyN(&out, zr, 1024); err != nil && err != io.EOF {
+	if _, err = io.CopyN(&out, zr, 1024); err != nil && !errors.Is(err, io.EOF) {
 		zr.Close()
 		return nil, err
 	}
@@ -64,7 +65,7 @@ func FlateDecompress(data []byte) ([]byte, error) {
 	buf := bytes.NewBuffer(data)
 	zr := flate.NewReader(buf)
 	out := bytes.Buffer{}
-	if _, err = io.CopyN(&out, zr, 1024); err != nil && err != io.EOF {
+	if _, err = io.CopyN(&out, zr, 1024); err != nil && !errors.Is(err, io.EOF) {
 		zr.Close()
 		return nil, err
 	}

--- a/exporter/awskinesisexporter/internal/compress/compresser_test.go
+++ b/exporter/awskinesisexporter/internal/compress/compresser_test.go
@@ -4,43 +4,106 @@
 package compress_test
 
 import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"compress/zlib"
 	"fmt"
+	"io"
 	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/internal/compress"
 )
+
+func GzipDecompress(data []byte) ([]byte, error) {
+	buf := bytes.NewBuffer(data)
+
+	zr, err := gzip.NewReader(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	out := bytes.Buffer{}
+	if _, err = io.Copy(&out, zr); err != nil {
+		zr.Close()
+		return nil, err
+	}
+	zr.Close()
+	return out.Bytes(), nil
+}
+
+func NoopDecompress(data []byte) ([]byte, error) {
+	return data, nil
+}
+
+func ZlibDecompress(data []byte) ([]byte, error) {
+	buf := bytes.NewBuffer(data)
+
+	zr, err := zlib.NewReader(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	out := bytes.Buffer{}
+	if _, err = io.Copy(&out, zr); err != nil {
+		zr.Close()
+		return nil, err
+	}
+	zr.Close()
+	return out.Bytes(), nil
+}
+
+func FlateDecompress(data []byte) ([]byte, error) {
+	var err error
+	buf := bytes.NewBuffer(data)
+	zr := flate.NewReader(buf)
+	out := bytes.Buffer{}
+	if _, err = io.Copy(&out, zr); err != nil {
+		zr.Close()
+		return nil, err
+	}
+	zr.Close()
+	return out.Bytes(), nil
+}
 
 func TestCompressorFormats(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		format string
+		format     string
+		decompress func(data []byte) ([]byte, error)
 	}{
-		{format: "none"},
-		{format: "noop"},
-		{format: "gzip"},
-		{format: "zlib"},
-		{format: "flate"},
+		{format: "none", decompress: NoopDecompress},
+		{format: "noop", decompress: NoopDecompress},
+		{format: "gzip", decompress: GzipDecompress},
+		{format: "zlib", decompress: ZlibDecompress},
+		{format: "flate", decompress: FlateDecompress},
 	}
 
 	const data = "You know nothing Jon Snow"
+
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("format_%s", tc.format), func(t *testing.T) {
-			c, err := compress.NewCompressor(tc.format)
+			logger := zaptest.NewLogger(t)
+			c, err := compress.NewCompressor(tc.format, logger)
 			require.NoError(t, err, "Must have a valid compression format")
 			require.NotNil(t, c, "Must have a valid compressor")
 
 			out, err := c.Do([]byte(data))
 			assert.NoError(t, err, "Must not error when processing data")
 			assert.NotNil(t, out, "Must have a valid record")
+			outDecompress, err := tc.decompress(out)
+			assert.NoError(t, err, "Decompression must have no errors")
+			assert.Equal(t, []byte(data), outDecompress, "Data input should be the same after compression and decompression")
 		})
 	}
-	_, err := compress.NewCompressor("invalid-format")
+	_, err := compress.NewCompressor("invalid-format", zaptest.NewLogger(t))
 	assert.Error(t, err, "Must error when an invalid compression format is given")
 }
 
@@ -82,7 +145,7 @@ func benchmarkCompressor(b *testing.B, format string, length int) {
 	source := rand.NewSource(time.Now().UnixMilli())
 	genRand := rand.New(source)
 
-	compressor, err := compress.NewCompressor(format)
+	compressor, err := compress.NewCompressor(format, zaptest.NewLogger(b))
 	require.NoError(b, err, "Must not error when given a valid format")
 	require.NotNil(b, compressor, "Must have a valid compressor")
 

--- a/exporter/awskinesisexporter/internal/compress/compresser_test.go
+++ b/exporter/awskinesisexporter/internal/compress/compresser_test.go
@@ -30,7 +30,7 @@ func GzipDecompress(data []byte) ([]byte, error) {
 	}
 
 	out := bytes.Buffer{}
-	if _, err = io.Copy(&out, zr); err != nil {
+	if _, err = io.CopyN(&out, zr, 1024); err != nil && err != io.EOF {
 		zr.Close()
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func ZlibDecompress(data []byte) ([]byte, error) {
 	}
 
 	out := bytes.Buffer{}
-	if _, err = io.Copy(&out, zr); err != nil {
+	if _, err = io.CopyN(&out, zr, 1024); err != nil && err != io.EOF {
 		zr.Close()
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func FlateDecompress(data []byte) ([]byte, error) {
 	buf := bytes.NewBuffer(data)
 	zr := flate.NewReader(buf)
 	out := bytes.Buffer{}
-	if _, err = io.Copy(&out, zr); err != nil {
+	if _, err = io.CopyN(&out, zr, 1024); err != nil && err != io.EOF {
 		zr.Close()
 		return nil, err
 	}

--- a/exporter/awskinesisexporter/internal/compress/noop_compression.go
+++ b/exporter/awskinesisexporter/internal/compress/noop_compression.go
@@ -3,7 +3,10 @@
 
 package compress // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/internal/compress"
 
-import "io"
+import (
+	"io"
+	"sync"
+)
 
 type noop struct {
 	data io.Writer
@@ -11,7 +14,11 @@ type noop struct {
 
 func NewNoopCompressor() Compressor {
 	return &compressor{
-		compression: &noop{},
+		compressionPool: sync.Pool{
+			New: func() any {
+				return &noop{}
+			},
+		},
 	}
 }
 
@@ -23,6 +30,6 @@ func (n noop) Write(p []byte) (int, error) {
 	return n.data.Write(p)
 }
 
-func (n noop) Flush() error {
+func (n noop) Close() error {
 	return nil
 }


### PR DESCRIPTION
## Description

There are two main changes in this PR:
* Fixing a bug relating to the compression with EOF markers added in
* Adding `sync.pool` for the compressor so that it is thread safe

### 1st bug
When checking the output of the gzip compressed data, there are errors such as:
```
EOFError: Compressed file ended before the end-of-stream marker was reached

Received unexpected error: unexpected EOF
```

This affects zlib, flate and gzip

This is because the `Flush` does not added the EOF markers. `Close()` is required be called to mark the EOF.

**Fix:** Changed `Flush` to `Close` so that EOF markers are added to end of compressed payload


### 2nd bug
There is a race condition with the compressor because the queued retry allows multiple consumers - [see here for documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md)

Hence, when there is a retry in the kinesis exporter, it can cause a race condition as the concurrent consumers are reusing the same compressor object
```
│ compress/flate.(*huffmanBitWriter).indexTokens(0xc0000523c0, {0xc04ed22000, 0x4e4, 0xd?})                                                                                                                                                                                     │
│     GOROOT/src/compress/flate/huffman_bit_writer.go:551 +0x2a5                                                                                                                                                                                                                │
│ compress/flate.(*huffmanBitWriter).writeBlockDynamic(0xc0000523c0, {0xc04ed22000?, 0xc0580b75e0?, 0x6b90a2?}, 0x0?, {0xc04ecac000, 0x31aa, 0xffff})                                                                                                                           │
│     GOROOT/src/compress/flate/huffman_bit_writer.go:509 +0xc5                                                                                                                                                                                                                 │
│ compress/flate.(*compressor).encSpeed(0xc04ec02000)                                                                                                                                                                                                                           │
│     GOROOT/src/compress/flate/deflate.go:362 +0x259                                                                                                                                                                                                                           │
│ compress/flate.(*compressor).close(0xc04ec02000)                                                                                                                                                                                                                              │
│     GOROOT/src/compress/flate/deflate.go:638 +0x76                                                                                                                                                                                                                            │
│ compress/flate.(*Writer).Close(...)                                                                                                                                                                                                                                           │
│     GOROOT/src/compress/flate/deflate.go:730                                                                                                                                                                                                                                  │
│ compress/gzip.(*Writer).Close(0xc000a548f0)                                                                                                                                                                                                                                   │
│     GOROOT/src/compress/gzip/gzip.go:242 +0x87                                                                                                                                                                                                                                │
│ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/internal/compress.(*compressor).Do(0xc0005205d0, {0xc07ed42000, 0x31aa, 0x31aa})                                                                                                        │
│     external/com_github_open_telemetry_opentelemetry_collector_contrib_exporter_awskinesisexporter/internal/compress/compresser.go:84 +0x99                                                                                                                                   │
│ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/internal/batch.(*Batch).AddRecord(0xc07a1f6740, {0xc07ed42000?, 0xc0580b7748?, 0xc0580b7748?}, {0xc07e7cce70, 0x24})                                                                    │
│     external/com_github_open_telemetry_opentelemetry_collector_contrib_exporter_awskinesisexporter/internal/batch/batch.go:92 +0x57                                                                                                                                           │
│ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/internal/batch.(*batchMarshaller).Logs(0xc00051e460, {0x49bfa0?})                                                                                                                       │
│     external/com_github_open_telemetry_opentelemetry_collector_contrib_exporter_awskinesisexporter/internal/batch/encode_marshaler.go:64 +0x1ef                                                                                                                               │
│ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter.Exporter.consumeLogs({{0x4575ce0?, 0xc0002ee940?}, {0x4580b10?, 0xc00051e460?}}, {0x4594908, 0xc07625acc0}, {0x4594940?})                                                               │
│     external/com_github_open_telemetry_opentelemetry_collector_contrib_exporter_awskinesisexporter/exporter.go:152 +0x48                                                                                                                                                      │
│ go.opentelemetry.io/collector/exporter/exporterhelper.(*logsRequest).Export(0x4594940?, {0x4594908?, 0xc07625acc0?})                                                                                                                                                          │
│     external/io_opentelemetry_go_collector_exporter/exporterhelper/logs.go:65 +0x34                                                                                                                                                                                           │
│ go.opentelemetry.io/collector/exporter/exporterhelper.(*timeoutSender).send(0xc000443778, {0x45a4208, 0xc07ea37440})                                                                                                                                                          │
│     external/io_opentelemetry_go_collector_exporter/exporterhelper/common.go:208 +0x96                                                                                                                                                                                        │
│ go.opentelemetry.io/collector/exporter/exporterhelper.(*retrySender).send(0xc00068f900, {0x45a4208, 0xc07ea37440})                                                                                                                                                            │
│     external/io_opentelemetry_go_collector_exporter/exporterhelper/queued_retry.go:394 +0x596                                                                                                                                                                                 │
│ go.opentelemetry.io/collector/exporter/exporterhelper.(*logsExporterWithObservability).send(0xc0003c6b10, {0x45a4208, 0xc07ea37440})                                                                                                                                          │
│     external/io_opentelemetry_go_collector_exporter/exporterhelper/logs.go:135 +0x88                                                                                                                                                                                          │
│ go.opentelemetry.io/collector/exporter/exporterhelper.(*queuedRetrySender).start.func1({0x45a4208, 0xc07ea37440})                                                                                                                                                             │
│     external/io_opentelemetry_go_collector_exporter/exporterhelper/queued_retry.go:205 +0x39                                                                                                                                                                                  │
│ go.opentelemetry.io/collector/exporter/exporterhelper/internal.(*boundedMemoryQueue).StartConsumers.func1()                                                                                                                                                                   │
│     external/io_opentelemetry_go_collector_exporter/exporterhelper/internal/bounded_memory_queue.go:58 +0xb6                                                                                                                                                                  │
│ created by go.opentelemetry.io/collector/exporter/exporterhelper/internal.(*boundedMemoryQueue).StartConsumers                                                                                                                                                                │
│     external/io_opentelemetry_go_collector_exporter/exporterhelper/internal/bounded_memory_queue.go:53 +0x45
```
**Fix:** Used sync.pool to instantiate the compress writers so that it is goroutine safe
