### PR TITLE
[OTE-1506] Loadbalancer exporter: Add resource_keys routing for the traces

### DIFF
--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -17,13 +17,15 @@ const (
 	svcRouting
 	metricNameRouting
 	resourceRouting
+	resourceKeysRouting
 )
 
 // Config defines configuration for the exporter.
 type Config struct {
-	Protocol   Protocol         `mapstructure:"protocol"`
-	Resolver   ResolverSettings `mapstructure:"resolver"`
-	RoutingKey string           `mapstructure:"routing_key"`
+	Protocol     Protocol         `mapstructure:"protocol"`
+	Resolver     ResolverSettings `mapstructure:"resolver"`
+	RoutingKey   string           `mapstructure:"routing_key"`
+	ResourceKeys []string         `mapstructure:"resource_keys"`
 }
 
 // Protocol holds the individual protocol-specific settings. Only OTLP is supported at the moment.


### PR DESCRIPTION
[Ticket](https://canvadev.atlassian.net/browse/OTE-1506)

# Context
Resource-based load balancing is required for Canva reliability metrics.
Currently, we maintain [a copy of the load balancer in the otel-platform repo](https://github.com/Canva/otel-platform/tree/main/opentelemetry-collector/exporter/loadbalancingexporter). This copy is based on the old version (`v0.79.0`) and never updated with the upstream.
There are improvements and new features in the upstream version that potentially can resolve our public gateway migration issues. See [this thread](https://canva.slack.com/archives/C07RP8D2U0Y/p1729641360810589).

In this PR, we add resource_keys based load balancing to the opentelemetry-collector-contrib fork.

# Notes
- **Why didn't we simply copy the implementation from the old copy?** In this PR, we used a different approach to add resource_keys based load balancing.  Because it is simpler and more aligned with the rest of the load balancer, it enables us to keep our fork in sync with upstream easily. Also, it allows us to contribute changes upstream and eliminate this fork.
- **Does upstream accept this new feature?** Yes, there is [an open request for a limited version of this feature](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33660). And the last time we tried to contribute this feature to the upstream, [the plugin owner liked the feature but needed a more robust implementation](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/18769#pullrequestreview-1318332518).
- **Is this branch ready for a PR to upstream?** No, not yet
  - We will follow the [Otel collector contribution guideline](https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRIBUTING.md). This means we will start by raising an issue and describing the feature requirements. Once we get LGTM on that one, then we will raise a PR.
  - To minimise changes on our side, we used our old config namings (`routing_key: resource`) in this PR, which conflicts with [the new versions' features](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/loadbalancingexporter#trace-idservice-name-aware-load-balancing-exporter).
  - To keep this PR small, we only added a resource_keys based load balancer to traces. We must add it to metrics and logs before raising it to the upstream.
  - This is based on `v0.102.0` and not the upstream master (Preparing for `v0.112.0`). We need to rebase with the upstream master to prevent conflicts.
  - We skipped README.md and CHANGELOG.md updates.